### PR TITLE
fix: Gradle group name

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 kotlin.code.style=official
 org.gradle.parallel=true
 kotlin.incremental=true
-group=com.github.rushyverse
+group=com.github.Rushyverse
 version=1.0.0
 description=Library to create Minestom server for Rushyverse


### PR DESCRIPTION
To keep coherence with Jitpack and the group name, we need to set to uppercase the first letter of the github group in gradle

rushyverse -> Rushyverse