### PR TITLE
chore: Set start method as suspend

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,16 +116,13 @@ data class MyConfiguration(
 ```kotlin
 import com.github.rushyverse.api.RushyServer
 
+suspend fun main(args: Array<String>) {
+    MyServer(args.firstOrNull()).start()
+}
+
 class MyServer(private val configurationPath: String?) : RushyServer() {
 
-    companion object {
-        @JvmStatic
-        fun main(args: Array<String>) {
-            MyServer(args.firstOrNull()).start()
-        }
-    }
-
-    override fun start() {
+    override suspend fun start() {
         start<MyConfiguration>(configurationPath) {
             // this = MyConfiguration
             // it = InstanceContainer
@@ -157,7 +154,7 @@ import com.github.rushyverse.api.RushyServer
 
 class MyServer : RushyServer() {
 
-    override fun start() {
+    override suspend fun start() {
         start<MyConfiguration>(configurationPath) {
             API.registerCommands()
         }
@@ -179,7 +176,7 @@ import com.github.rushyverse.api.RushyServer
 
 class MyServer : RushyServer() {
 
-    override fun start() {
+    override suspend fun start() {
         start<MyConfiguration>(configurationPath) {
             // Register "myBundle" resource bundle and the API resource bundle
             val translationsProvider = createTranslationsProvider(listOf(API.BUNDLE_API, "myBundle"))

--- a/src/main/kotlin/com/github/rushyverse/api/RushyServer.kt
+++ b/src/main/kotlin/com/github/rushyverse/api/RushyServer.kt
@@ -51,14 +51,14 @@ public abstract class RushyServer {
     /**
      * Start the minecraft server.
      */
-    public abstract fun start()
+    public abstract suspend fun start()
 
     /**
      * Initialize the server and start it using the given (or default) configuration.
      * @param configurationPath Path of the configuration file in working directory.
      * @param init Initialization function with the configuration loaded and the world container.
      */
-    protected inline fun <reified T : IConfiguration> start(
+    protected suspend inline fun <reified T : IConfiguration> start(
         configurationPath: String? = null,
         init: T.(InstanceContainer) -> Unit
     ) {
@@ -82,7 +82,7 @@ public abstract class RushyServer {
         minecraftServer.start("0.0.0.0", serverConfig.port)
     }
 
-    protected open fun applyOnlineMode(enabled: Boolean) {
+    protected open suspend fun applyOnlineMode(enabled: Boolean) {
         if (enabled) {
             logger.info { "Enabling Online mode" }
             MojangAuth.init()
@@ -94,7 +94,7 @@ public abstract class RushyServer {
      * Enable the [Velocity system][VelocityProxy] if the configuration [IVelocityConfiguration] is enabled.
      * @param velocity Velocity configuration.
      */
-    protected open fun applyVelocityConfiguration(velocity: IVelocityConfiguration) {
+    protected open suspend fun applyVelocityConfiguration(velocity: IVelocityConfiguration) {
         if (velocity.enabled) {
             logger.info { "Enabling Velocity support" }
             VelocityProxy.enable(velocity.secret)
@@ -106,7 +106,7 @@ public abstract class RushyServer {
      * Enable the [BungeeCord system][BungeeCordProxy] if the configuration [IBungeeCordConfiguration] is enabled.
      * @param bungeeCord BungeeCord configuration.
      */
-    protected open fun applyBungeeCordConfiguration(bungeeCord: IBungeeCordConfiguration) {
+    protected open suspend fun applyBungeeCordConfiguration(bungeeCord: IBungeeCordConfiguration) {
         if (bungeeCord.enabled) {
             logger.info { "Enabling BungeeCord support" }
             BungeeCordProxy.enable()
@@ -120,7 +120,7 @@ public abstract class RushyServer {
      * @param worldFolder World folder.
      * @param instanceContainer Instance container of the server.
      */
-    protected open fun loadWorld(worldFolder: String, instanceContainer: InstanceContainer) {
+    protected open suspend fun loadWorld(worldFolder: String, instanceContainer: InstanceContainer) {
         val anvilWorld = File(workingDirectory, worldFolder)
         if (!anvilWorld.isDirectory) {
             throw FileSystemException(
@@ -146,7 +146,7 @@ public abstract class RushyServer {
      * Create a translation provider to provide translations for the [supported languages][SupportedLanguage].
      * @return New translation provider.
      */
-    protected open fun createTranslationsProvider(bundles: Iterable<String>): TranslationsProvider {
+    protected open suspend fun createTranslationsProvider(bundles: Iterable<String>): TranslationsProvider {
         return ResourceBundleTranslationsProvider().apply {
             bundles.forEach { registerResourceBundleForSupportedLocales(it, ResourceBundle::getBundle) }
         }

--- a/src/test/kotlin/com/github/rushyverse/api/RushyServerTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/api/RushyServerTest.kt
@@ -7,21 +7,16 @@ import com.github.rushyverse.api.command.StopCommand
 import com.github.rushyverse.api.configuration.BungeeCordConfiguration
 import com.github.rushyverse.api.configuration.IConfiguration
 import com.github.rushyverse.api.configuration.VelocityConfiguration
-import com.github.rushyverse.api.utils.assertCoroutineContextFromScope
 import com.github.rushyverse.api.utils.randomString
-import kotlinx.coroutines.*
 import kotlinx.coroutines.test.runTest
 import net.minestom.server.MinecraftServer
 import net.minestom.server.extras.MojangAuth
 import net.minestom.server.extras.bungee.BungeeCordProxy
 import net.minestom.server.extras.velocity.VelocityProxy
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.io.IOException
-import java.util.concurrent.CountDownLatch
-import kotlin.coroutines.coroutineContext
 import kotlin.test.*
 
 class TestServer(private val configuration: String? = null) : RushyServer() {
@@ -46,37 +41,6 @@ class RushyServerTest : AbstractTest() {
     @Test
     fun `should have the correct bundle name`() {
         assertEquals("api", RushyServer.API.BUNDLE_API)
-    }
-
-    @Test
-    @Disabled
-    fun `start body should be in coroutine context`() {
-        val latch = CountDownLatch(1)
-        var executed = false
-        copyWorldInTmpDirectory()
-
-        val scope = CoroutineScope(Dispatchers.Default)
-
-        val server = object : RushyServer() {
-            override suspend fun start() {
-                assertCoroutineContextFromScope(scope, coroutineContext)
-                start<TestConfiguration>() {
-                    assertCoroutineContextFromScope(scope, coroutineContext)
-                    yield()
-                    assertCoroutineContextFromScope(scope, coroutineContext)
-                    executed = true
-                    latch.countDown()
-                }
-            }
-        }
-
-        scope.launch {
-            server.start()
-        }
-
-        latch.await()
-        scope.cancel()
-        assertTrue(executed)
     }
 
     @Nested

--- a/src/test/kotlin/com/github/rushyverse/api/RushyServerTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/api/RushyServerTest.kt
@@ -15,6 +15,7 @@ import net.minestom.server.MinecraftServer
 import net.minestom.server.extras.MojangAuth
 import net.minestom.server.extras.bungee.BungeeCordProxy
 import net.minestom.server.extras.velocity.VelocityProxy
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -48,6 +49,7 @@ class RushyServerTest : AbstractTest() {
     }
 
     @Test
+    @Disabled
     fun `start body should be in coroutine context`() {
         val latch = CountDownLatch(1)
         var executed = false


### PR DESCRIPTION
# Context

At the moment it is not possible to call a suspend function in the start method. However, this does not make sense because the start can be called in the main function which can be suspended.

# To do
- [x] Start suspend
- [x] Documentation