### PR TITLE
feat: Use icu4j for translation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,12 +21,14 @@ dependencies {
     val coroutinesCoreVersion = "1.6.4"
     val kotlinSerializationVersion = "1.4.1"
     val commonsNetVersion = "3.9.0"
+    val icu4jVersion = "72.1"
 
     implementation(kotlin("stdlib"))
     implementation(kotlin("reflect"))
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesCoreVersion")
     implementation("com.github.Minestom.Minestom:Minestom:$minestomVersion")
     implementation("commons-net:commons-net:$commonsNetVersion")
+    implementation("com.ibm.icu:icu4j:$icu4jVersion")
 
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:$kotlinSerializationVersion")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-hocon:$kotlinSerializationVersion")

--- a/src/main/kotlin/com/github/rushyverse/api/translation/ResourceBundleTranslationsProvider.kt
+++ b/src/main/kotlin/com/github/rushyverse/api/translation/ResourceBundleTranslationsProvider.kt
@@ -1,7 +1,7 @@
 package com.github.rushyverse.api.translation
 
+import com.ibm.icu.text.MessageFormat
 import mu.KotlinLogging
-import java.text.MessageFormat
 import java.util.*
 
 /**
@@ -35,7 +35,7 @@ public open class ResourceBundleTranslationsProvider : TranslationsProvider() {
         key: String,
         locale: Locale,
         bundleName: String,
-        replacements: Array<String>
+        replacements: Array<Any>
     ): String {
         val string = try {
             get(key, locale, bundleName)

--- a/src/main/kotlin/com/github/rushyverse/api/translation/TranslationsProvider.kt
+++ b/src/main/kotlin/com/github/rushyverse/api/translation/TranslationsProvider.kt
@@ -19,7 +19,7 @@ public abstract class TranslationsProvider {
         key: String,
         locale: Locale,
         bundleName: String,
-        replacements: Array<String>
+        replacements: Array<Any>
     ): String
 
     /**
@@ -38,6 +38,6 @@ public abstract class TranslationsProvider {
         key: String,
         locale: Locale,
         bundleName: String,
-        replacements: Collection<String>
+        replacements: Collection<Any>
     ): String = translate(key, locale, bundleName, replacements.toTypedArray())
 }

--- a/src/test/kotlin/com/github/rushyverse/api/translation/ResourceBundleTranslationsProviderTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/api/translation/ResourceBundleTranslationsProviderTest.kt
@@ -167,5 +167,29 @@ class ResourceBundleTranslationsProviderTest {
                 provider.translate("test_args", SupportedLanguage.ENGLISH.locale, BUNDLE_NAME)
             )
         }
+
+        @Test
+        fun `should return the value with plural syntax`() {
+            provider.registerResourceBundle(BUNDLE_NAME, SupportedLanguage.ENGLISH.locale, ResourceBundle::getBundle)
+            assertEquals(
+                "Need 2 players.",
+                provider.translate("test_plural", SupportedLanguage.ENGLISH.locale, BUNDLE_NAME, arrayOf(2))
+            )
+        }
+
+        @Test
+        fun `should return the value with singular syntax`() {
+            provider.registerResourceBundle(BUNDLE_NAME, SupportedLanguage.ENGLISH.locale, ResourceBundle::getBundle)
+            assertEquals(
+                "Need 1 player.",
+                provider.translate("test_plural", SupportedLanguage.ENGLISH.locale, BUNDLE_NAME, arrayOf(1))
+            )
+
+            assertEquals(
+                "Need 0 player.",
+                provider.translate("test_plural", SupportedLanguage.ENGLISH.locale, BUNDLE_NAME, arrayOf(0))
+            )
+        }
+
     }
 }

--- a/src/test/kotlin/com/github/rushyverse/api/translation/ResourceBundleTranslationsProviderTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/api/translation/ResourceBundleTranslationsProviderTest.kt
@@ -191,5 +191,14 @@ class ResourceBundleTranslationsProviderTest {
             )
         }
 
+        @Test
+        fun `should return the UTF-8 value`() {
+            provider.registerResourceBundle(BUNDLE_NAME, SupportedLanguage.FRENCH.locale, ResourceBundle::getBundle)
+            assertEquals(
+                "français_value_1",
+                provider.translate("test1", SupportedLanguage.FRENCH.locale, BUNDLE_NAME)
+            )
+        }
+
     }
 }

--- a/src/test/resources/test_bundle.properties
+++ b/src/test/resources/test_bundle.properties
@@ -1,3 +1,4 @@
+test_plural=Need {0} {0, plural, =0 {player} =1 {player} other {players}}.
 test1=default_value_1
 test2=default_value_2
 test_args=default_value {0}

--- a/src/test/resources/test_bundle_en_GB.properties
+++ b/src/test/resources/test_bundle_en_GB.properties
@@ -1,3 +1,4 @@
+test_plural=Need {0} {0, plural, =0 {player} =1 {player} other {players}}.
 test1=english_value_1
 test2=english_value_2
 test_args=english_value {0}

--- a/src/test/resources/test_bundle_fr_FR.properties
+++ b/src/test/resources/test_bundle_fr_FR.properties
@@ -1,4 +1,4 @@
 test_plural=Besoin de {0} {0, plural, =0 {joueur} =1 {joueur} other {joueurs}}.
-test1=français_value_1
-test2=français_value_2
-test_args=français_value {0}
+test1=franÃ§ais_value_1
+test2=franÃ§ais_value_2
+test_args=franÃ§ais_value {0}

--- a/src/test/resources/test_bundle_fr_FR.properties
+++ b/src/test/resources/test_bundle_fr_FR.properties
@@ -1,3 +1,4 @@
+test_plural=Need {0} {0, plural, =0 {player}, =1 {player}, other {players}}.
 test1=français_value_1
 test2=français_value_2
 test_args=français_value {0}

--- a/src/test/resources/test_bundle_fr_FR.properties
+++ b/src/test/resources/test_bundle_fr_FR.properties
@@ -1,4 +1,4 @@
-test_plural=Need {0} {0, plural, =0 {player}, =1 {player}, other {players}}.
+test_plural=Besoin de {0} {0, plural, =0 {joueur} =1 {joueur} other {joueurs}}.
 test1=français_value_1
 test2=français_value_2
 test_args=français_value {0}


### PR DESCRIPTION
# Context

Currently, the `MessageFormat` used is imported from java library. However this class doesn't allow to parse plural syntax.

# To do
- [x] Use ICU4J
- [x] Tests