### PR TITLE
chore: Change way to check clicked item

### DIFF
--- a/src/main/kotlin/com/github/rushyverse/api/extension/InventoryExt.kt
+++ b/src/main/kotlin/com/github/rushyverse/api/extension/InventoryExt.kt
@@ -69,7 +69,7 @@ public fun AbstractInventory.registerClickEventOnItem(
     handler: InventoryCondition
 ): InventoryCondition {
     val condition = InventoryCondition { player, clickedSlot, clickType, result ->
-        if (clickedSlot in slots && identifier.areSame(item, getItemStack(clickedSlot))) {
+        if (identifier.areSame(item, result.clickedItem)) {
             handler.accept(player, clickedSlot, clickType, result)
         }
     }


### PR DESCRIPTION
# Context

Currently, the item is retrieved by getting it using the clicked slot.  However this value is already set in the result value by Minestom