### PR TITLE
feat: Add mini message extension

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,17 +21,19 @@ dependencies {
     val kotlinSerializationVersion = "1.5.0"
     val commonsNetVersion = "3.9.0"
     val icu4jVersion = "72.1"
+    val minimessageVersion = "4.12.0"
 
     api(kotlin("stdlib"))
     api(kotlin("reflect"))
     api("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
     api("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:$coroutinesVersion")
+    api("org.jetbrains.kotlinx:kotlinx-serialization-core:$kotlinSerializationVersion")
+    api("org.jetbrains.kotlinx:kotlinx-serialization-hocon:$kotlinSerializationVersion")
+
     api("com.github.Minestom.Minestom:Minestom:$minestomVersion")
     api("commons-net:commons-net:$commonsNetVersion")
     api("com.ibm.icu:icu4j:$icu4jVersion")
-
-    api("org.jetbrains.kotlinx:kotlinx-serialization-core:$kotlinSerializationVersion")
-    api("org.jetbrains.kotlinx:kotlinx-serialization-hocon:$kotlinSerializationVersion")
+    api("net.kyori:adventure-text-minimessage:$minimessageVersion")
 
     // Logging information
     api("io.github.microutils:kotlin-logging:$loggingVersion")

--- a/src/main/kotlin/com/github/rushyverse/api/extension/StringExt.kt
+++ b/src/main/kotlin/com/github/rushyverse/api/extension/StringExt.kt
@@ -3,6 +3,8 @@ package com.github.rushyverse.api.extension
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.TextComponent
 import net.kyori.adventure.text.format.NamedTextColor
+import net.kyori.adventure.text.minimessage.MiniMessage
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver
 
 /**
  * Default max line for a lore line.
@@ -89,3 +91,14 @@ public fun String.toFormattedLoreSequence(lineLength: Int = DEFAULT_LORE_LINE_LE
         }
     }
 }
+
+/**
+ * Transforms a string into a component using MiniMessage.
+ * Will set the color according to the tag in the string.
+ * The [tagResolver] will be used to resolve the custom tags and replace values.
+ * @receiver The string used to create the component.
+ * @param tagResolver The tag resolver used to resolve the custom tags.
+ * @return The component created from the string.
+ */
+public fun String.asMiniComponent(vararg tagResolver: TagResolver): Component =
+    MiniMessage.miniMessage().deserialize(this, *tagResolver)

--- a/src/test/kotlin/com/github/rushyverse/api/extension/StringExtTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/api/extension/StringExtTest.kt
@@ -1,10 +1,14 @@
 package com.github.rushyverse.api.extension
 
 import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.TextComponent
+import net.kyori.adventure.text.event.ClickEvent
 import net.kyori.adventure.text.format.NamedTextColor
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder
 import org.junit.jupiter.api.Nested
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 
 class StringExtTest {
 
@@ -283,5 +287,55 @@ class StringExtTest {
                 "Add, chat and join your friends through the server".toFormattedLoreSequence(40).toList(),
             )
         }
+    }
+
+    @Nested
+    inner class AsMiniComponent {
+
+        @Test
+        fun `should return simple component text with simple string`() {
+            val string = "Hello World!"
+            val component = string.asMiniComponent()
+            component as TextComponent
+            assertEquals("Hello World!", component.content())
+        }
+
+        @Test
+        fun `should return component text with color`() {
+            val string = "<red>Hello World!</red>"
+            val component = string.asMiniComponent()
+            component as TextComponent
+
+            assertEquals("Hello World!", component.content())
+
+            val color = component.color()
+            assertNotNull(color)
+            assertEquals("#ff5555", color.asHexString())
+        }
+
+        @Test
+        fun `should return component with click event`() {
+            val string = "<click:run_command:/test>Click me!</click>"
+            val component = string.asMiniComponent()
+            component as TextComponent
+
+            assertEquals("Click me!", component.content())
+
+            val clickEvent = component.clickEvent()
+            assertNotNull(clickEvent)
+            assertEquals(ClickEvent.Action.RUN_COMMAND, clickEvent.action())
+            assertEquals("/test", clickEvent.value())
+        }
+
+        @Test
+        fun `should return component with custom tag`() {
+            val string = "Hello <test>!"
+            val component = string.asMiniComponent(
+                Placeholder.unparsed("test", "my test")
+            )
+            component as TextComponent
+            assertEquals("Hello my test!", component.content())
+        }
+
     }
 }


### PR DESCRIPTION
# Context

To improve how components are created using a configuration file, we should use [MiniMessage](https://docs.advntr.dev/minimessage/format.html).

# To do
- [x] Extension function
- [x] Tests