### PR TITLE
fix(jitpack): Minimize jar size and resolve Jitpack build issue

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -144,6 +144,8 @@ tasks {
     }
 
     dokkaHtml.configure {
+        // CompileJava should be executed to build library in Jitpack
+        dependsOn(deleteDokkaOutputDir, compileJava.get())
         outputDirectory.set(file(dokkaOutputDir))
     }
 
@@ -161,6 +163,7 @@ tasks {
 }
 
 val deleteDokkaOutputDir by tasks.register<Delete>("deleteDokkaOutputDirectory") {
+    group = "documentation"
     delete(dokkaOutputDir)
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -135,10 +135,6 @@ tasks {
         useJUnitPlatform()
     }
 
-    build {
-        dependsOn(shadowJar)
-    }
-
     clean {
         delete(dokkaOutputDir)
     }
@@ -147,10 +143,6 @@ tasks {
         // CompileJava should be executed to build library in Jitpack
         dependsOn(deleteDokkaOutputDir, compileJava.get())
         outputDirectory.set(file(dokkaOutputDir))
-    }
-
-    shadowJar {
-        archiveClassifier.set("")
     }
 
     jacocoTestReport {
@@ -168,28 +160,33 @@ val deleteDokkaOutputDir by tasks.register<Delete>("deleteDokkaOutputDirectory")
 }
 
 val sourcesJar by tasks.registering(Jar::class) {
+    group = "build"
     archiveClassifier.set("sources")
     from(sourceSets.main.get().allSource)
 }
 
 val javadocJar = tasks.register<Jar>("javadocJar") {
+    group = "documentation"
+    dependsOn(tasks.dokkaHtml)
     dependsOn(deleteDokkaOutputDir, tasks.dokkaHtml)
     archiveClassifier.set("javadoc")
     from(dokkaOutputDir)
 }
 
 publishing {
+    val projectName = project.name
+
     publications {
-        val projectOrganizationPath = "Rushyverse/${project.name}"
+        val projectOrganizationPath = "Rushyverse/$projectName"
         val projectGitUrl = "https://github.com/$projectOrganizationPath"
 
-        create<MavenPublication>(project.name) {
-            shadow.component(this)
+        create<MavenPublication>(projectName) {
+            from(components["kotlin"])
             artifact(sourcesJar.get())
             artifact(javadocJar.get())
 
             pom {
-                name.set(project.name)
+                name.set(projectName)
                 description.set(project.description)
                 url.set(projectGitUrl)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,30 +43,29 @@ dependencies {
     val mockBukkitVersion = "3.18.0"
     val junitVersion = "5.9.0"
     val mockkVersion = "1.12.5"
-    val slf4jVersion = "2.0.0-alpha6"
     val fastboardVersion = "2.0.0"
     val kotestVersion = "5.6.2"
     val icu4jVersion = "73.2"
 
-    implementation(kotlin("stdlib"))
-    implementation(kotlin("stdlib-jdk8"))
-    implementation(kotlin("reflect"))
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:$kotlinSerializableVersion")
-    implementation("com.charleskorn.kaml:kaml:$kamlVersion")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutineVersion")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:$coroutineVersion")
-    implementation("io.github.microutils:kotlin-logging:$loggingVersion")
+    api(kotlin("stdlib"))
+    api(kotlin("stdlib-jdk8"))
+    api(kotlin("reflect"))
+    api("org.jetbrains.kotlinx:kotlinx-serialization-core:$kotlinSerializableVersion")
+    api("com.charleskorn.kaml:kaml:$kamlVersion")
+    api("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutineVersion")
+    api("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:$coroutineVersion")
+    api("io.github.microutils:kotlin-logging:$loggingVersion")
 
     // Plural translation
-    implementation("com.ibm.icu:icu4j:$icu4jVersion")
+    api("com.ibm.icu:icu4j:$icu4jVersion")
 
     // Injection framework
-    implementation("io.insert-koin:koin-core:$koinVersion")
-    implementation("io.insert-koin:koin-logger-slf4j:$koinVersion")
+    api("io.insert-koin:koin-core:$koinVersion")
+    api("io.insert-koin:koin-logger-slf4j:$koinVersion")
 
     // MC coroutine framework
-    implementation("com.github.shynixn.mccoroutine:mccoroutine-bukkit-api:$mccoroutineVersion")
-    implementation("com.github.shynixn.mccoroutine:mccoroutine-bukkit-core:$mccoroutineVersion")
+    api("com.github.shynixn.mccoroutine:mccoroutine-bukkit-api:$mccoroutineVersion")
+    api("com.github.shynixn.mccoroutine:mccoroutine-bukkit-core:$mccoroutineVersion")
 
     // Minecraft server framework
     "io.papermc.paper:paper-api:$paperVersion".let {
@@ -75,7 +74,7 @@ dependencies {
     }
 
     // Scoreboard framework
-    implementation("fr.mrmicky:fastboard:$fastboardVersion")
+    api("fr.mrmicky:fastboard:$fastboardVersion")
 
     api("com.github.Rushyverse:core:6ae31a9250")
 


### PR DESCRIPTION
The 2.0.0 was not published due to an error during the build.

Jitpack is a bit weird, with this branch, if you take the dependency `com.github.Rushyverse:api:fix~jitpack_publish-7e76dc1424-1` that doesn't work but with `com.github.Rushyverse:api:fix~jitpack_publish-SNAPSHOT` works